### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This library simplifies programming of robot Cing.
 category=Uncategorized
 url=http://robotcing.wz.sk
 architectures=*
+depends=OneWire, DallasTemperature, Adafruit NeoPixel, MPU6050_tockn, IRremote, VL53L0X, Servo, Adafruit ADS1X15, Adafruit BME280 Library, Adafruit Unified Sensor, LiquidCrystal I2C


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format